### PR TITLE
made grenache client timeout configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ TODO
 ./config/*.json
 data
 status
+dist/

--- a/src/Grenache/Client.js
+++ b/src/Grenache/Client.js
@@ -20,11 +20,11 @@ module.exports = class GrenacheClient {
   // @name: Name of the worker
   // @params.method: Method of the worker
   // @params.args: arguments passed to the worker
-  send (name, params, cb) {
+  send (name, params, cb, timeoutMs=600000) {
     const fn = cb || function (err) {
       if (err) throw err
     }
-    this.peer.request(name, params, { timeout: 600000 }, (err, data) => {
+    this.peer.request(name, params, { timeout: timeoutMs }, (err, data) => {
       if (err && err.message.includes('ERR_GRAPE_LOOKUP_EMPTY')) {
         console.log('Cannot find service', name, params)
       }


### PR DESCRIPTION
`GrenacheClient.send` takes a new optional parameter `timeoutMs`. Default: 600s. Before, the timeout was fixed to 600s. This makes it changeable by the user. This change is backwards compatible.

```js
const client = new GrenacheClient()
const callback = (err, data) => {}
const timeout = 10*1000
client.send('functionName', 'myParameter', callback, timeout)
```